### PR TITLE
Remove colout dependency and add --quiet flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Usage: pachist [options] [number of lines]
 	-v, --verbose	Show verbose messages
 	    --err		Not as verbose, just warning messages
 	<number>		Rows of lines to show
+	-q, --quiet		Show less information
 
 The configuration file can be found at ~/.config/pachist.conf and currently holds ability to change default colors and number of lines to be shown.
 

--- a/pachist
+++ b/pachist
@@ -83,32 +83,31 @@ check_args() {
 
 
 ## The command that makes it happen.
-filter() {
-	awk -F' ' /\($fltr_1\|$fltr_2\|$fltr_3\|$fltr_4\|$fltr_5\|$fltr_6\|$fltr_7\|starting\)/'{if ($4!="" && $5!="full") print $1,$2,substr($0, index($0,$3)+length($3)+1); else if ($5="full") print "";}' /var/log/pacman.log
+filter_and_format_output() {
+	keywords="$fltr_1|$fltr_2|$fltr_3|$fltr_4|$fltr_5|$fltr_6|$fltr_7"
+	boot_time=$(date +"%F %H:%M" -d "$(cut -f1 -d. /proc/uptime) seconds ago")
 
-}
+	awk -F' ' -v  boot_time="${boot_time}" /\("$keywords"\)/'{
+	if ($3 == "[ALPM-SCRIPTLET]" || $4 == "warning:") {
+		print $1, $2, substr($0, index($0,$3)+length($3)+1)
+	} else if ($3 == "[ALPM]") {
+		red = "\033[31m"
+		off = "\033[1;0m"
 
-## Insert last reboot.. (thanks to ymonad @ stackoverflow for this one)
-insert_reboot() {
-	fg="\e[0;;31m" # red color
-	BOOT_TIME=$(date +"%F %H:%M" -d "$(cut -f1 -d. /proc/uptime) seconds ago")
-	REBOOT_FLAG=""
-	while read line; do
-  		TMP1=${line%]*}
-  		TMP2=${TMP1#[}
-  		if [ -z "$REBOOT_FLAG" ] && [ "$TMP2" \> "$BOOT_TIME" ]; then
-			echo
-			echo -e "[$BOOT_TIME] "$fg"SYSTEM REBOOT (last)"
-			echo
-			REBOOT_FLAG="true"
-  		fi
-	echo "$line"
-	done
-}
+		if (match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}/)) {
+			date = substr($0, RSTART, RLENGTH)
+			if (!reboot_flag && date > boot_time) {
+				print ""
+				print "[" boot_time "]" red " SYSTEM REBOOT (last)" off
+				print ""
+				reboot_flag = "1";
+			}
+		}
 
-## Add some formatting and reboot message
-formatting() {
-	insert_reboot < <(filter | cat -s)
+		print $1, $2, $4, $5, substr($0, index($0,$6))
+	} else if (substr($0, index($0,$3)) == "[PACMAN] starting full system upgrade") {
+		print ""
+	}}' /var/log/pacman.log | cat -s
 }
 
 ## execute and show the endresult
@@ -121,7 +120,7 @@ run_pachist() {
 	check_args $@
 	get_colors
 
-	formatting | colout '(\[.*\]) (starting.*|upgraded.*|downgraded.*|installed.*|reinstalled.*|removed.*) (\(.*\))' $col_1,$col_2,$col_3 | tail -n$lines
+	filter_and_format_output | colout '(\[.*\]) (starting.*|upgraded.*|downgraded.*|installed.*|reinstalled.*|removed.*) (\(.*\))' $col_1,$col_2,$col_3 | tail -n$lines
 }
 
 run_pachist $@

--- a/pachist
+++ b/pachist
@@ -60,11 +60,31 @@ usage() {
 	exit 0
 }
 
+get_color_code() {
+	COLOR_CODE=""
+
+	case "${1,,}" in
+		"black") COLOR_CODE="\033[1;30m" ;;
+		"blue")  COLOR_CODE="\033[1;34m" ;;
+		"green") COLOR_CODE="\033[1;32m" ;;
+		"cyan")  COLOR_CODE="\033[1;36m" ;;
+		"red")   COLOR_CODE="\033[1;31m" ;;
+		"gray")  COLOR_CODE="\033[1;30m" ;;
+		"purple")COLOR_CODE="\033[1;35m" ;;
+		"yellow")COLOR_CODE="\033[1;33m" ;;
+		"white") COLOR_CODE="\033[1;37m" ;;
+		*)       COLOR_CODE="\033[1;0m" ;;
+	esac
+
+	echo "${COLOR_CODE}"
+}
+
+
 get_colors() {
 	## fetch colors from config
-	col_1="$(awk -F'"' '/color1/{print $2}' $HOME/.config/pachist.conf)"
-	col_2="$(awk -F'"' '/color2/{print $2}' $HOME/.config/pachist.conf)"
-	col_3="$(awk -F'"' '/color3/{print $2}' $HOME/.config/pachist.conf)"
+	col_1="$(get_color_code $(awk -F'"' '/color1/{print $2}' $HOME/.config/pachist.conf))"
+	col_2="$(get_color_code $(awk -F'"' '/color2/{print $2}' $HOME/.config/pachist.conf))"
+	col_3="$(get_color_code $(awk -F'"' '/color3/{print $2}' $HOME/.config/pachist.conf))"
 }
 
 check_args() {
@@ -87,7 +107,7 @@ filter_and_format_output() {
 	keywords="$fltr_1|$fltr_2|$fltr_3|$fltr_4|$fltr_5|$fltr_6|$fltr_7"
 	boot_time=$(date +"%F %H:%M" -d "$(cut -f1 -d. /proc/uptime) seconds ago")
 
-	awk -F' ' -v  boot_time="${boot_time}" /\("$keywords"\)/'{
+	awk -F' ' -v  boot_time="${boot_time}" -v col_1=$col_1 -v col_2=$col_2 -v col_3=$col_3 /\("$keywords"\)/'{
 	if ($3 == "[ALPM-SCRIPTLET]" || $4 == "warning:") {
 		print $1, $2, substr($0, index($0,$3)+length($3)+1)
 	} else if ($3 == "[ALPM]") {
@@ -104,7 +124,7 @@ filter_and_format_output() {
 			}
 		}
 
-		print $1, $2, $4, $5, substr($0, index($0,$6))
+		print col_1 $1, $2, col_2 $4, $5, col_3 substr($0, index($0,$6)) off
 	} else if (substr($0, index($0,$3)) == "[PACMAN] starting full system upgrade") {
 		print ""
 	}}' /var/log/pacman.log | cat -s
@@ -120,7 +140,7 @@ run_pachist() {
 	check_args $@
 	get_colors
 
-	filter_and_format_output | colout '(\[.*\]) (starting.*|upgraded.*|downgraded.*|installed.*|reinstalled.*|removed.*) (\(.*\))' $col_1,$col_2,$col_3 | tail -n$lines
+	filter_and_format_output | tail -n$lines
 }
 
 run_pachist $@

--- a/pachist
+++ b/pachist
@@ -47,6 +47,7 @@ usage() {
 	printf "$(gettext "   -h, --help		Show this help")\n"
 	printf "$(gettext "   -v, --verbose	Show messages")\n"
 	printf "$(gettext "       --err		Not as verbose, just warning messages")\n"
+	printf "$(gettext "   -q, --quiet               Show less information")\n"
 	printf "$(gettext "   <number>		Number of lines to show")\n\n"
 
 	printf "$(gettext "examples:")\n"
@@ -94,6 +95,7 @@ check_args() {
       		-h|--help) usage ;;
       		-v|--verbose) fltr_7="\[ALPM-SCRIPTLET\]|[Ww]arning" ;;
 		--err) fltr_7="[Ww]arning" ;;
+		-q|--quiet) quiet=1 ;;
       		*[0-9]*) lines=$(echo $* | grep -o "[0-9]*");;
       		*) args[${#args[@]}]=$1 ;;
 		esac
@@ -107,8 +109,10 @@ filter_and_format_output() {
 	keywords="$fltr_1|$fltr_2|$fltr_3|$fltr_4|$fltr_5|$fltr_6|$fltr_7"
 	boot_time=$(date +"%F %H:%M" -d "$(cut -f1 -d. /proc/uptime) seconds ago")
 
-	awk -F' ' -v  boot_time="${boot_time}" -v col_1=$col_1 -v col_2=$col_2 -v col_3=$col_3 /\("$keywords"\)/'{
-	if ($3 == "[ALPM-SCRIPTLET]" || $4 == "warning:") {
+	awk -F' ' -v  boot_time="${boot_time}" -v quiet=$quiet -v col_1=$col_1 -v col_2=$col_2 -v col_3=$col_3 /\("$keywords"\)/'{
+	if (quiet) {
+		if ($3 == "[ALPM]" && $4 != "warning:") print $5
+	} else if ($3 == "[ALPM-SCRIPTLET]" || $4 == "warning:") {
 		print $1, $2, substr($0, index($0,$3)+length($3)+1)
 	} else if ($3 == "[ALPM]") {
 		red = "\033[31m"


### PR DESCRIPTION
This pull request will:
- Move logic into the *awk* code.
- Remove the *colout* dependency by using color codes instead.
- Add a *--quiet* flag.

The *--quiet* flag is great to have when you for instance installed a AUR package that has a lot of dependencies (or if the dependencies in turn has a lot dependencies) and you removed the original package but not every dependensy. Or if you canceled the installation process (e.g. in *yaourt*), resulting in that some dependencies were installed but not the original package. Anyhow, you could do something like this:
```
yaourt -S pkgWithAlotOfDependecies
pachist -q 22 | pacman -R -
```

*pachist* also runs faster with these changes (although it's already pretty fast :). On my laptop I got the following (average) times when running ```time pachist -v 2000 > /dev/null```.

*before changes:*
```
real	0m0.423s
user	0m0.663s
sys		0m0.117s
```
*after changes:*
```
real	0m0.097s
user	0m0.077s
sys		0m0.003s
```
